### PR TITLE
Added a new 'downward' mode

### DIFF
--- a/src/Rephlux/PageTitle/PageTitle.php
+++ b/src/Rephlux/PageTitle/PageTitle.php
@@ -82,14 +82,18 @@ class PageTitle implements Countable
         if ($this->count() == 0) {
             return $this->default;
         }
-
+        
+        if ($direction === 'downward') {
+            $this->collection = array_reverse($this->collection);
+        }
+        
         $this->addPageName();
+        
+        if ($direction === 'reverse') {
+            $this->collection = array_reverse($this->collection);
+        }
 
-        return implode(
-            $this->delimeter,
-            $direction === 'reverse' ? array_reverse($this->collection) : $this->collection
-        );
-
+        return implode($this->delimeter, $this->collection);
     }
 
     /**


### PR DESCRIPTION
It like 'reverse' but shifts 'site name' at the end of title. Useful when pagetitle called inside the constructor (ex. 'News') and then inside the function you added category title and then item title.

With regular it would be like: News | Category | Post | Site name
With reverse : Site name | Post | Category | News
With downward: Post | Category | News | Site Name