### PR TITLE
Updated composer.json to work with Laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
         }
     ],
     "require": {
-        "php" : "~5.6|~7.0",
-        "illuminate/support": "~5.0.0|~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.0"
+        "php" : "~7.1",
+        "illuminate/support": "~5.6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7"
+        "phpunit/phpunit": "~7.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/PageTitleTest.php
+++ b/tests/PageTitleTest.php
@@ -2,7 +2,7 @@
 
 namespace Rephlux\PageTitle\Test;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Rephlux\PageTitle\PageTitle;
 
 /**
@@ -10,7 +10,7 @@ use Rephlux\PageTitle\PageTitle;
  *
  * @author Chris van Daele <engine_no9@gmx.net>
  */
-class PageTitleTest extends PHPUnit_Framework_TestCase
+class PageTitleTest extends TestCase
 {
     /**
      * @var PageTitle


### PR DESCRIPTION
Would be great if laravel-pagetitle could be bumped to be compatible with Laravel 5.6 as illuminate/support 5.5 composer requirement currently breaks the update to 5.6 from 5.5. Thanks 👍 